### PR TITLE
Make OME-XML companion generation/consumption optional (default off)

### DIFF
--- a/config/deriva_imaging.json
+++ b/config/deriva_imaging.json
@@ -12,6 +12,7 @@
     "viewer": "openseadragon-viewer/mview.html",
     "log": ".../logs/deriva_imaging.log",
     "loglevel": "debug",
+    "generate_ome_companion": false,
     "image_processing_status": "processing_status",
     "original_file_name": "filename",
     "get_claimable_url": "/entity/isa:imaging_data/processing_status=new;processing_status=renew/filename::ciregexp::%5B.%5D%28tif%5Bf%5D%7B0%2C1%7D%7Cjpg%7Cpng%7Cnii%28%5B.%5Dgz%29%7B0%2C1%7D%7Caim%7Cmnc%7Cam%29%24?limit=1",

--- a/deriva_imaging_pipeline/client.py
+++ b/deriva_imaging_pipeline/client.py
@@ -254,6 +254,9 @@ def get_configuration(cfg: dict[str, Any], log: logging.Logger) -> Optional[dict
     # Optional with default: version
     config['version'] = cfg.get('version', 'v1.0')
 
+    # Optional with default: generate_ome_companion (off by default)
+    config['generate_ome_companion'] = cfg.get('generate_ome_companion', False)
+
     # Optional: mail settings
     config['mail_server'] = cfg.get('mail_server')
     config['mail_sender'] = cfg.get('mail_sender')

--- a/deriva_imaging_pipeline/worker.py
+++ b/deriva_imaging_pipeline/worker.py
@@ -131,6 +131,7 @@ class DerivaImagingWorker:
         """
         self.missing_scenes = False
         self.z_threshold = os.getenv('z_threshold', 5)
+        self.generate_ome_companion = kwargs.get('generate_ome_companion', False)
         self.model = kwargs.get('model')
         self.hatrac_template = kwargs.get('hatrac_template')
         self.iiif_url = kwargs.get('iiif_url')
@@ -906,21 +907,22 @@ class DerivaImagingWorker:
         if (Metadata_URL, Metadata_Name, Metadata_Bytes, Metadata_MD5) == (None, None, None, None):
             return 1
         companion = []
-        for companion_ome in self.ome_xml:
-            try:
-                r = re.search('.*[-]s[0-9]+[-]z([0-9]+)[.]companion[.]ome', companion_ome).group(1)
-                if z_index_no <= self.z_threshold and int(r) == middle_z_index or z_index_no > self.z_threshold:
+        if self.generate_ome_companion:
+            for companion_ome in self.ome_xml:
+                try:
+                    r = re.search('.*[-]s[0-9]+[-]z([0-9]+)[.]companion[.]ome', companion_ome).group(1)
+                    if z_index_no <= self.z_threshold and int(r) == middle_z_index or z_index_no > self.z_threshold:
+                        companion_file = self.storeFileInHatrac(companion_ome, '/var/www/html/{}'.format(self.output_metadata), rid)
+                        if companion_file == (None, None, None, None):
+                            return 1
+                        else:
+                            companion.append(companion_file)
+                except:
                     companion_file = self.storeFileInHatrac(companion_ome, '/var/www/html/{}'.format(self.output_metadata), rid)
                     if companion_file == (None, None, None, None):
                         return 1
                     else:
                         companion.append(companion_file)
-            except:
-                companion_file = self.storeFileInHatrac(companion_ome, '/var/www/html/{}'.format(self.output_metadata), rid)
-                if companion_file == (None, None, None, None):
-                    return 1
-                else:
-                    companion.append(companion_file)
 
         """
         Get the scenes
@@ -1272,9 +1274,12 @@ class DerivaImagingWorker:
                 
         """
         Build now the Image_Z record
+
+        Only when companion generation is enabled: Image_Z rows require non-null
+        OME_Companion_* columns, so without companions there is nothing to record.
         """
-        for pyramid in self.tiff_files:
-            if channels_no > 1:
+        if self.generate_ome_companion and channels_no > 1:
+            for pyramid in self.tiff_files:
                 if z_index_no <= self.z_threshold and pyramid['z'] != middle_z_index:
                     continue
                 
@@ -1577,7 +1582,7 @@ class DerivaImagingWorker:
             os.chdir(self.data_scratch)
             self.logger.debug('Executing: extract_scenes.run({}, {})'.format(filename, 'processing_dir='.format(self.processing_dir)))
             try:
-                extract_scenes.run(filename, processing_dir=self.processing_dir)
+                extract_scenes.run(filename, processing_dir=self.processing_dir, generate_companion=self.generate_ome_companion)
                 os.chdir(currentDirectory)
             except:
                 os.chdir(currentDirectory)
@@ -1647,12 +1652,13 @@ class DerivaImagingWorker:
                 if series_details[0][self.physicalSizeXUnit] in self.micrometer:
                     self.resolutions = [(int) (10**6 / float(series_details[0][self.physicalSizeX]))]
                     
+            if self.generate_ome_companion:
+                for entry in os.scandir('{}/{}'.format(self.data_scratch, fname)):
+                    if entry.is_file() and entry.path.endswith('.companion.ome'):
+                        self.ome_xml.append(entry.name)
+
             for entry in os.scandir('{}/{}'.format(self.data_scratch, fname)):
-                if entry.is_file() and entry.path.endswith('.companion.ome'):
-                    self.ome_xml.append(entry.name)
-            
-            for entry in os.scandir('{}/{}'.format(self.data_scratch, fname)):
-                if entry.is_file() and (entry.path.endswith('.json') or entry.path.endswith('.companion.ome')):
+                if entry.is_file() and (entry.path.endswith('.json') or (self.generate_ome_companion and entry.path.endswith('.companion.ome'))):
                     shutil.copy(entry.path, '/var/www/html/{}'.format(self.output_metadata))
             
             for entry in os.scandir('{}/{}'.format(self.data_scratch, fname)):

--- a/deriva_imaging_pipeline/worker.py
+++ b/deriva_imaging_pipeline/worker.py
@@ -240,13 +240,17 @@ class DerivaImagingWorker:
                     ready = True
         elif self.mail_file != None:
             """
-            Put the mail message into the mail.log file
+            Put the mail message into the mail.log file.
+
+            Written as a single append (one write) to reduce interleaving when
+            multiple services share this file. The body starts with the current
+            UTC time so messages can be ordered/disambiguated.
             """
+            timestamp = time.strftime('%Y-%m-%d %H:%M:%S UTC', time.gmtime())
             fw = open(self.mail_file, 'a')
-            fw.write('Subject: {}\n'.format(subject))
-            fw.write('Body:\n{}\n\n'.format(text))
+            fw.write('Subject: {}\nBody:\n{}\n{}\n\n'.format(subject, timestamp, text))
             fw.close()
-            
+
             return
             """
             Send the mail with the Linux mail utility


### PR DESCRIPTION
This PR closes #5 by making the companion file generation optional. I also made a small adjustment to the `mail.log` generation so we're capturing the timestamp of when the error occurred.